### PR TITLE
Splitted sync logic from VM to sync service (#58)

### DIFF
--- a/PasswordManager/Models/CredentialsMergeResult.cs
+++ b/PasswordManager/Models/CredentialsMergeResult.cs
@@ -9,6 +9,7 @@ namespace PasswordManager.Models
     {
         public IList<Credential> NewCredentials { get; } = new List<Credential>();
         public IList<Credential> ChangedCredentials { get; } = new List<Credential>();
+        public bool AnyChanges => NewCredentials.Count > 0 || ChangedCredentials.Count > 0;
 
         public override string ToString()
         {

--- a/PasswordManager/Services/SyncService.cs
+++ b/PasswordManager/Services/SyncService.cs
@@ -2,6 +2,9 @@
 using PasswordManager.Cloud.Enums;
 using PasswordManager.Clouds.Services;
 using PasswordManager.Helpers;
+using PasswordManager.Models;
+using PasswordManager.Views.InputBox;
+using PasswordManager.Views.MessageBox;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -13,68 +16,103 @@ namespace PasswordManager.Services
     public class SyncService
     {
         private readonly CloudServiceProvider _cloudServiceProvider;
-        private readonly AppSettingsService _appSettingsService;
         private readonly ILogger<SyncService> _logger;
-        private readonly object _syncCTSLock = new();
-
-        private CancellationTokenSource _syncCTS;
-
-        public bool SyncInProgress { get; private set; }
-        public event Action<bool> SyncReport;
+        private readonly CredentialsCryptoService _credentialsCryptoService;
+        private readonly CryptoService _cryptoService;
+        private readonly HashSet<CloudType> _syncClouds = new();
+        // TODO: implement IDisposable
+        private readonly CancellationTokenSource _syncCTS = new();
 
         public SyncService(
             CloudServiceProvider cloudServiceProvider,
-            AppSettingsService appSettingsService,
+            CredentialsCryptoService credentialsCryptoService,
+            CryptoService cryptoService,
             ILogger<SyncService> logger)
         {
             _cloudServiceProvider = cloudServiceProvider;
-            _appSettingsService = appSettingsService;
             _logger = logger;
+            _credentialsCryptoService = credentialsCryptoService;
+            _cryptoService = cryptoService;
         }
 
-        public async Task Synchronize()
+        public async Task Synchronize(CloudType cloudType)
         {
-            SyncReport?.Invoke(true);
-
-            CancellationToken cancellationToken;
-            lock (_syncCTSLock)
+            lock (_syncClouds)
             {
-                _syncCTS?.Cancel();
-                _syncCTS = new CancellationTokenSource();
-                cancellationToken = _syncCTS.Token;
+                if (!_syncClouds.Add(cloudType))
+                {
+                    _logger.LogInformation($"Sync for \'{cloudType}\' is in processing");
+                    return;
+                }
             }
 
             try
             {
-                var cloudTypesToSync = new List<CloudType>();
-                if (_appSettingsService.GoogleDriveEnabled)
+                var windowDialogName = MvvmHelper.MainWindowDialogName;
+                var token = _syncCTS.Token;
+                var cloudService = _cloudServiceProvider.GetCloudService(cloudType);
+
+                using var cloudFileStream = await cloudService.Download(Constants.PasswordsFileName, token);
+                if (cloudFileStream != null)
                 {
-                    cloudTypesToSync.Add(CloudType.GoogleDrive);
+                    // File exists
+                    List<Credential> cloudCredentials = null;
+                    var password = _credentialsCryptoService.GetPassword();
+
+                    do
+                    {
+                        try
+                        {
+                            cloudCredentials = _cryptoService.DecryptFromStream<List<Credential>>(cloudFileStream, password);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, string.Empty);
+                        }
+
+                        if (cloudCredentials is null)
+                        {
+                            password = await MaterialInputBox.ShowAsync(
+                                "Input password of cloud file",
+                                "Password",
+                                windowDialogName,
+                                true);
+
+                            if (password is null)
+                                return; // Cancel operation
+                        }
+                    }
+                    while (cloudCredentials is null);
+
+                    // Merge
+                    var mergeResult = await _credentialsCryptoService.Merge(cloudCredentials);
+                    await MaterialMessageBox.ShowAsync(
+                        "Credentials successfully merged",
+                        mergeResult.ToString(),
+                        MaterialMessageBoxButtons.OK,
+                        windowDialogName);
                 }
 
-                using var ms = new MemoryStream();
-                using (var fileStream = File.Open(Constants.PasswordsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                {
-                    await fileStream.CopyToAsync(ms, cancellationToken);
-                }
-
-                foreach (var cloudType in cloudTypesToSync)
-                {
-                    // Ensure begining
-                    ms.Seek(0, SeekOrigin.Begin);
-                    var cloudService = _cloudServiceProvider.GetCloudService(cloudType);
-                    await cloudService.Upload(ms, Constants.PasswordsFileName, cancellationToken);
-                }
-
-                SyncReport?.Invoke(false);
+                using var fileStream = File.Open(Constants.PasswordsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                // Ensure begining
+                fileStream.Seek(0, SeekOrigin.Begin);
+                await cloudService.Upload(fileStream, Constants.PasswordsFileName, token);
             }
             catch (OperationCanceledException)
             {
-                _logger.LogWarning("Synchronize has been cancelled");
+                _logger.LogWarning($"Synchronize for \'{cloudType}\' has been cancelled");
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, string.Empty);
+            }
+            finally
+            {
+                lock (_syncClouds)
+                {
+                    _syncClouds.Remove(cloudType);
+                    _logger.LogInformation($"Synchronize for \'{cloudType}\' completed");
+                }
             }
         }
     }

--- a/PasswordManager/ViewModels/PasswordsViewModel.cs
+++ b/PasswordManager/ViewModels/PasswordsViewModel.cs
@@ -40,7 +40,6 @@ namespace PasswordManager.ViewModels
         public event Action<CredentialViewModel> CredentialSelected;
 
         private readonly CredentialsCryptoService _credentialsCryptoService;
-        private readonly SyncService _syncService;
         private readonly ILogger<PasswordsViewModel> _logger;
         private readonly List<CredentialViewModel> _credentials = new();
         private CredentialViewModel _selectedCredential;
@@ -87,7 +86,6 @@ namespace PasswordManager.ViewModels
 
         public PasswordsViewModel(
             CredentialsCryptoService credentialsCryptoService,
-            SyncService syncService,
             ILogger<PasswordsViewModel> logger,
             CredentialsDialogViewModel credentialsDialogViewModel)
         {
@@ -95,20 +93,12 @@ namespace PasswordManager.ViewModels
             IconKind = PackIconKind.Password;
 
             _credentialsCryptoService = credentialsCryptoService;
-            _syncService = syncService;
             _logger = logger;
-
-            _syncService.SyncReport += SyncService_SyncReport;
 
             ActiveCredentialDialogViewModel = credentialsDialogViewModel;
             ActiveCredentialDialogViewModel.Accept += ActiveCredentialDialogViewModel_Accept;
             ActiveCredentialDialogViewModel.Cancel += ActiveCredentialDialogViewModel_Cancel;
             ActiveCredentialDialogViewModel.Delete += ActiveCredentialDialogViewModel_Delete;
-        }
-
-        private void SyncService_SyncReport(bool obj)
-        {
-            Loading = obj;
         }
 
         private async void ActiveCredentialDialogViewModel_Delete(CredentialViewModel credVM)

--- a/PasswordManager/ViewModels/SettingsViewModel.cs
+++ b/PasswordManager/ViewModels/SettingsViewModel.cs
@@ -97,7 +97,7 @@ namespace PasswordManager.ViewModels
                 Loading = true;
 
                 _credentialsCryptoService.SetPassword(NewPassword);
-                await _credentialsCryptoService.SaveCredentialsAndSync();
+                await _credentialsCryptoService.SaveCredentials();
 
                 NewPasswordIsSet?.Invoke();
                 success = true;


### PR DESCRIPTION
Also don't auto-sync when any password changed - user should resolve it, not a program and we need to merge credentials - more consistent process
Sync processing - don't restart sync if already in process (multiple button pressed)
Stages: Download file, try to decrypt, merge, upload file
Fixed fetch user info - don't restart fetch if already in process
Don't notify in passwords view model about sync